### PR TITLE
Feature/nearby restraunts(DRAFT)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "next": "15.1.7",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.0.1",
+        "tailwind-merge": "^3.0.2",
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
@@ -5481,9 +5481,9 @@
       }
     },
     "node_modules/tailwind-merge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.1.tgz",
-      "integrity": "sha512-AvzE8FmSoXC7nC+oU5GlQJbip2UO7tmOhOfQyOmPhrStOGXHU08j8mZEHZ4BmCqY5dWTCo4ClWkNyRNx1wpT0g==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.2.tgz",
+      "integrity": "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "next": "15.1.7",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.0.1",
+    "tailwind-merge": "^3.0.2",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {

--- a/src/app/(routes)/api/restraunts/route.ts
+++ b/src/app/(routes)/api/restraunts/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server"
+
+export async function GET(request: NextRequest) {
+  const searchParams = request.nextUrl.searchParams
+  const lat = searchParams.get("lat")
+  const lng = searchParams.get("lng")
+  const res = await fetch(`http://localhost:8080/restaurants/nearby?x=${lng}&y=${lat}5&d=100`)
+    .then((res) => res.json())
+    .catch((err) => err)
+
+  return Response.json({ res })
+}

--- a/src/app/(routes)/test/kakao/page.tsx
+++ b/src/app/(routes)/test/kakao/page.tsx
@@ -1,10 +1,20 @@
 "use client"
 import KakaoMap from "@/components/map/KakaoMap"
 import useGeolocation from "@/hooks/useGeolocation"
+import { useEffect } from "react"
+
+const getRestraunts = () => {
+  return fetch("http://localhost:8080/restaurants/nearby?x=127.12909643077252&y=37.41204078264615&d=100")
+}
 
 export default function KakaoMapPage() {
   const { loaded, coordinates, error } = useGeolocation()
-  console.log("test", loaded, coordinates, error)
+  // useEffect(() => {
+  //   ;async () => {
+  //     const res = await getRestraunts()
+  //     console.log("res", res)
+  //   }
+  // }, [])
   return (
     <div>
       <KakaoMap

--- a/src/app/(routes)/test/kakao/page.tsx
+++ b/src/app/(routes)/test/kakao/page.tsx
@@ -1,27 +1,9 @@
-"use client"
-import { useEffect, useRef } from "react"
+import KakaoMap from "@/components/map/KakaoMap"
 
-export default function Home() {
-  const kakaoMapContainer = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const kakao = window?.kakao
-    if (kakaoMapContainer?.current && typeof kakao !== "undefined") {
-      const container = kakaoMapContainer.current
-      kakao.maps.load(() => {
-        const options = {
-          center: new kakao.maps.LatLng(33.450701, 126.570667),
-          level: 3
-        }
-
-        const map = new kakao.maps.Map(container, options)
-      })
-    }
-  }, [kakaoMapContainer])
-
+export default function KakaoMapPage() {
   return (
     <div>
-      <div id="map" ref={kakaoMapContainer} className="h-[500px] w-[500px]"></div>
+      <KakaoMap className="h-[100vh] w-[100vw]" />
     </div>
   )
 }

--- a/src/app/(routes)/test/kakao/page.tsx
+++ b/src/app/(routes)/test/kakao/page.tsx
@@ -3,18 +3,19 @@ import KakaoMap from "@/components/map/KakaoMap"
 import useGeolocation from "@/hooks/useGeolocation"
 import { useEffect } from "react"
 
-const getRestraunts = () => {
-  return fetch("http://localhost:8080/restaurants/nearby?x=127.12909643077252&y=37.41204078264615&d=100")
+const getRestraunts = (lat: number, lng: number) => {
+  return fetch(`/api/restraunts?lat=${lat}&lng=${lng}`)
 }
 
 export default function KakaoMapPage() {
   const { loaded, coordinates, error } = useGeolocation()
-  // useEffect(() => {
-  //   ;async () => {
-  //     const res = await getRestraunts()
-  //     console.log("res", res)
-  //   }
-  // }, [])
+  useEffect(() => {
+    if (!(coordinates?.lat && coordinates?.lng)) return
+    getRestraunts(coordinates.lat, coordinates.lng).then(async (data) => {
+      const res = await data.json()
+      console.log("data", res)
+    })
+  }, [coordinates])
   return (
     <div>
       <KakaoMap

--- a/src/app/(routes)/test/kakao/page.tsx
+++ b/src/app/(routes)/test/kakao/page.tsx
@@ -1,9 +1,16 @@
+"use client"
 import KakaoMap from "@/components/map/KakaoMap"
+import useGeolocation from "@/hooks/useGeolocation"
 
 export default function KakaoMapPage() {
+  const { loaded, coordinates, error } = useGeolocation()
+  console.log("test", loaded, coordinates, error)
   return (
     <div>
-      <KakaoMap className="h-[100vh] w-[100vw]" />
+      <KakaoMap
+        className="h-[100vh] w-[100vw]"
+        myLocation={coordinates?.lat && coordinates.lng ? { ...coordinates } : undefined}
+      />
     </div>
   )
 }

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,0 +1,31 @@
+"use client"
+import { cn } from "@/utils/cn"
+import type { HTMLAttributes } from "react"
+import { useEffect, useRef } from "react"
+
+interface Params extends HTMLAttributes<HTMLDivElement> {}
+
+export default function KakaoMap({ ...htmlAttributes }: Params) {
+  const kakaoMapContainer = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const kakao = window?.kakao
+    if (kakaoMapContainer?.current && typeof kakao !== "undefined") {
+      const container = kakaoMapContainer.current
+      kakao.maps.load(() => {
+        const options = {
+          center: new kakao.maps.LatLng(33.450701, 126.570667),
+          level: 3
+        }
+
+        const map = new kakao.maps.Map(container, options)
+      })
+    }
+  }, [kakaoMapContainer])
+
+  return (
+    <div>
+      <div id="map" ref={kakaoMapContainer} className={cn("h-full w-full", htmlAttributes.className)}></div>
+    </div>
+  )
+}

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -1,12 +1,29 @@
 "use client"
 import { cn } from "@/utils/cn"
 import type { HTMLAttributes } from "react"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
-interface Params extends HTMLAttributes<HTMLDivElement> {}
+interface Params extends HTMLAttributes<HTMLDivElement> {
+  myLocation?: { lat: number; lng: number }
+}
 
-export default function KakaoMap({ ...htmlAttributes }: Params) {
+export default function KakaoMap({ myLocation, ...htmlAttributes }: Params) {
   const kakaoMapContainer = useRef<HTMLDivElement>(null)
+  const [kakaoMap, setkakaoMap] = useState<KaoKaoMap>()
+
+  useEffect(() => {
+    if (!myLocation) return
+    const kakao = window?.kakao
+    if (!kakaoMapContainer?.current || typeof kakao === "undefined") return
+    if (!kakaoMap) return
+    const markerPosition = new kakao.maps.LatLng(myLocation.lat, myLocation.lng)
+    const marker = new kakao.maps.Marker({
+      position: markerPosition
+    })
+
+    marker.setMap(kakaoMap)
+    kakaoMap.setCenter(markerPosition)
+  }, [myLocation, kakaoMapContainer.current])
 
   useEffect(() => {
     const kakao = window?.kakao
@@ -19,6 +36,7 @@ export default function KakaoMap({ ...htmlAttributes }: Params) {
         }
 
         const map = new kakao.maps.Map(container, options)
+        setkakaoMap(map)
       })
     }
   }, [kakaoMapContainer])

--- a/src/components/map/KakaoMap.tsx
+++ b/src/components/map/KakaoMap.tsx
@@ -23,7 +23,7 @@ export default function KakaoMap({ myLocation, ...htmlAttributes }: Params) {
 
     marker.setMap(kakaoMap)
     kakaoMap.setCenter(markerPosition)
-  }, [myLocation, kakaoMapContainer.current])
+  }, [myLocation?.lat, myLocation?.lng, kakaoMap])
 
   useEffect(() => {
     const kakao = window?.kakao
@@ -37,6 +37,14 @@ export default function KakaoMap({ myLocation, ...htmlAttributes }: Params) {
 
         const map = new kakao.maps.Map(container, options)
         setkakaoMap(map)
+        if (!myLocation) return
+        const markerPosition = new kakao.maps.LatLng(myLocation.lat, myLocation.lng)
+        const marker = new kakao.maps.Marker({
+          position: markerPosition
+        })
+
+        marker.setMap(map)
+        map.setCenter(markerPosition)
       })
     }
   }, [kakaoMapContainer])

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,8 +5,13 @@ declare global {
     getLng(): number
   }
 
-  class Map {
+  class KaoKaoMap {
     constructor(container: HTMLDivElement, options: MapOptions)
+    setCenter(latLng: LatLng): void
+  }
+  class Marker {
+    constructor({ position: LatLng })
+    setMap(map: KaoKaoMap): void
   }
 
   type MapOptions = {
@@ -17,7 +22,8 @@ declare global {
     kakao: {
       maps: {
         LatLng: typeof LatLng
-        Map: typeof Map
+        Map: typeof KaoKaoMap
+        Marker: typeof Marker
         load: (fn: () => void) => void
       }
     }

--- a/src/hooks/useGeolocation.tsx
+++ b/src/hooks/useGeolocation.tsx
@@ -1,0 +1,52 @@
+import { error } from "console"
+import { useEffect, useState } from "react"
+
+interface locationType {
+  loaded: boolean
+  coordinates?: { lat: number; lng: number }
+  error?: { code: number; message: string }
+}
+
+export default function useGeolocation() {
+  const [location, setLocation] = useState<locationType>({
+    loaded: false,
+    coordinates: { lat: 0, lng: 0 }
+  })
+
+  const onSuccess = (location: { coords: { latitude: number; longitude: number } }) => {
+    setLocation({
+      loaded: true,
+      coordinates: {
+        lat: location.coords.latitude,
+        lng: location.coords.longitude
+      }
+    })
+  }
+
+  const onError = (error: { code: number; message: string }) => {
+    setLocation({
+      loaded: true,
+      error
+    })
+  }
+  useEffect(() => {
+    if (!location.error) return
+    const err = location.error
+    if (err.code == 1) {
+      alert("위치 권한이 거부되었습니다. 브라우저 설정에서 권한을 허용해주세요.")
+    } else if (err.code === 2) {
+      alert("위치를 가져올 수 없습니다. 네트워크 상태를 확인하세요.")
+    }
+  }, [location])
+  useEffect(() => {
+    if (!("geolocation" in navigator)) {
+      console.log(navigator)
+      onError({
+        code: 0,
+        message: "Not Supported"
+      })
+    }
+    navigator.geolocation.getCurrentPosition(onSuccess, onError)
+  }, [navigator])
+  return location
+}

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}


### PR DESCRIPTION
map을 컴포넌트로 분리하기
- [x] tailwind-merge 사용해서 컴포넌트 부르는 부분에서 css 추기 할 수 있도록 구현(모바일 대응)
- [x] myLocation을 프롭스로 받아서 현재 내 위치로 지도 이동 및 마커 생성
        =>  마커는 추후에 빨간점으로 변경 예정
- [ ] 주변의 음식점 받아서 마커 생성

백엔드 연결 (음식점 정보 받기)
- [x]  cors 문제 해결 - 백엔드가 cors 허용이 되어있는 상태인지 현재 알 수 없어서 일단 Proxy로 해결
- [x]  fetch로 음식점 리스트 받기
- [ ]  데이터 가공( 현재 백에서 오는 데이터에서 음식점의 위치 정보를 알려면 문자열 파싱해야함)

추후에 react-query와 ky이용해서 서버와 통신 부분 리팩토링할 예정 
